### PR TITLE
feat: 全量拉取、增量拉取接口实现，客户端主动向服务端发送本地 seq 大小进行增量消息拉取

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,11 +6,8 @@
   <component name="ChangeListManager">
     <list default="true" id="3431669e-a84a-4e6a-a42b-133685b07059" name="Changes" comment="feat: 全量拉取、增量拉取接口实现，客户端主动向服务端发送本地 seq 大小进行增量消息拉取">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/im-domain/src/main/java/com/bantanger/im/domain/group/service/ImGroupService.java" beforeDir="false" afterPath="$PROJECT_DIR$/im-domain/src/main/java/com/bantanger/im/domain/group/service/ImGroupService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/im-domain/src/main/java/com/bantanger/im/domain/message/service/sync/MessageSyncServiceImpl.java" beforeDir="false" afterPath="$PROJECT_DIR$/im-domain/src/main/java/com/bantanger/im/domain/message/service/sync/MessageSyncServiceImpl.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/im-domain/src/main/java/com/bantanger/im/domain/user/controller/ImUserController.java" beforeDir="false" afterPath="$PROJECT_DIR$/im-domain/src/main/java/com/bantanger/im/domain/user/controller/ImUserController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/im-domain/src/main/java/com/bantanger/im/domain/user/service/ImUserService.java" beforeDir="false" afterPath="$PROJECT_DIR$/im-domain/src/main/java/com/bantanger/im/domain/user/service/ImUserService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/im-domain/src/main/java/com/bantanger/im/domain/user/service/impl/ImUserServiceImpl.java" beforeDir="false" afterPath="$PROJECT_DIR$/im-domain/src/main/java/com/bantanger/im/domain/user/service/impl/ImUserServiceImpl.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/im-domain/src/main/java/com/bantanger/im/domain/group/service/impl/ImGroupServiceImpl.java" beforeDir="false" afterPath="$PROJECT_DIR$/im-domain/src/main/java/com/bantanger/im/domain/group/service/impl/ImGroupServiceImpl.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/im-domain/src/test/java/SigApiTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/im-domain/src/test/java/SigApiTest.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -158,7 +155,7 @@
       </set>
     </option>
   </component>
-  <component name="RunManager" selected="Spring Boot.Domain">
+  <component name="RunManager" selected="JUnit.SigApiTest.test_poolSizeCalculator">
     <configuration name="Starter" type="Application" factoryName="Application">
       <option name="MAIN_CLASS_NAME" value="com.bantanger.im.tcp.Starter" />
       <module name="im-tcp" />
@@ -171,6 +168,16 @@
       <option name="MAIN_CLASS_NAME" value="com.bantanger.im.tcp.Starter" />
       <module name="im-tcp" />
       <option name="PROGRAM_PARAMETERS" value="E:\JavaProjectManager\whale-shark\im-tcp\src\main\resources\config2.yml" />
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="SigApiTest.test_poolSizeCalculator" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
+      <module name="im-domain" />
+      <option name="PACKAGE_NAME" value="" />
+      <option name="MAIN_CLASS_NAME" value="SigApiTest" />
+      <option name="METHOD_NAME" value="test_poolSizeCalculator" />
+      <option name="TEST_OBJECT" value="method" />
       <method v="2">
         <option name="Make" enabled="true" />
       </method>
@@ -236,9 +243,11 @@
       <item itemvalue="Python.login" />
       <item itemvalue="Spring Boot.Domain" />
       <item itemvalue="Spring Boot.Message-Store" />
+      <item itemvalue="JUnit.SigApiTest.test_poolSizeCalculator" />
     </list>
     <recent_temporary>
       <list>
+        <item itemvalue="JUnit.SigApiTest.test_poolSizeCalculator" />
         <item itemvalue="Python.login" />
         <item itemvalue="JUnit.SigApiTest.test_sigApi" />
       </list>
@@ -264,6 +273,7 @@
       <workItem from="1681008036555" duration="8266000" />
       <workItem from="1681055472622" duration="9143000" />
       <workItem from="1681368455405" duration="25673000" />
+      <workItem from="1681632287601" duration="1447000" />
     </task>
     <task id="LOCAL-00001" summary="feat: 采用策略模式重构命令执行逻辑">
       <created>1679715761283</created>

--- a/im-domain/src/main/java/com/bantanger/im/domain/group/service/impl/ImGroupServiceImpl.java
+++ b/im-domain/src/main/java/com/bantanger/im/domain/group/service/impl/ImGroupServiceImpl.java
@@ -518,11 +518,11 @@ public class ImGroupServiceImpl implements ImGroupService {
         SyncResp<ImGroupEntity> resp = new SyncResp<>();
 
         ResponseVO<Collection<String>> memberJoinedGroup = imGroupMemberService.syncMemberJoinedGroup(req.getOperater(), req.getAppId());
-        if(memberJoinedGroup.isOk()){
+        if (memberJoinedGroup.isOk()) {
 
             Collection<String> data = memberJoinedGroup.getData();
             QueryWrapper<ImGroupEntity> queryWrapper = new QueryWrapper<>();
-            queryWrapper.eq("app_id",req.getAppId());
+            queryWrapper.eq("app_id", req.getAppId());
             queryWrapper.in("group_id", data);
             queryWrapper.gt("sequence", req.getLastSequence());
             queryWrapper.last(" limit " + req.getMaxLimit());
@@ -530,7 +530,7 @@ public class ImGroupServiceImpl implements ImGroupService {
 
             List<ImGroupEntity> list = imGroupMapper.selectList(queryWrapper);
 
-            if(!CollectionUtils.isEmpty(list)){
+            if (!CollectionUtils.isEmpty(list)) {
                 ImGroupEntity maxSeqEntity = list.get(list.size() - 1);
                 resp.setDataList(list);
                 //设置最大seq
@@ -544,5 +544,17 @@ public class ImGroupServiceImpl implements ImGroupService {
         }
         resp.setCompleted(true);
         return ResponseVO.successResponse(resp);
+    }
+
+    @Override
+    public Long getUserGroupMaxSeq(String userId, Integer appId) {
+        ResponseVO<Collection<String>> memberJoinedGroup =
+                imGroupMemberService.syncMemberJoinedGroup(userId, appId);
+        if (!memberJoinedGroup.isOk()) {
+            throw new ApplicationException(500, "");
+        }
+        Long maxSeq = imGroupMapper.getJoinGroupMaxSeq(
+                memberJoinedGroup.getData(), appId);
+        return maxSeq;
     }
 }

--- a/im-domain/src/main/java/com/bantanger/im/domain/user/service/impl/ImUserServiceImpl.java
+++ b/im-domain/src/main/java/com/bantanger/im/domain/user/service/impl/ImUserServiceImpl.java
@@ -223,9 +223,10 @@ public class ImUserServiceImpl implements ImUserService {
 
     @Override
     public ResponseVO getUserSequence(GetUserSequenceReq req) {
-        // 将 redis 的缓存信息存入
+        // 将 redis 的缓存信息取出
         Map<Object, Object> map = stringRedisTemplate.opsForHash().entries(
                 req.getAppId() + ":" + Constants.RedisConstants.SeqPrefix + ":" + req.getUserId());
+        // 由于群组信息不在 redis 里，需要通过数据库查询出来并返回给客户端
         Long groupSeq = imGroupService.getUserGroupMaxSeq(req.getUserId(), req.getAppId());
         map.put(Constants.SeqConstants.GroupSeq, groupSeq);
         return ResponseVO.successResponse(map);


### PR DESCRIPTION
1. 服务端从 redis 中拉取出用户 userId 所需要拉取的消息偏序值
2. 由于群组消息偏序不是存储在 redis 而是数据库中，因此要额外的查询数据库并存入到 map 中一并返回给客户端